### PR TITLE
baseになるbranchを指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ build.gradleのライブラリを更新してGitHubにPullRequestを作成しま
 createLibraryUpdatePR {
     githubAccessToken = getProperty("github.token")
     githubPage = "https://github.com/orekyuu/LibraryVersionUpdater"
+    basedBranchName = "master"
 }
 
 // 下の設定を書かないとbetaなどにも更新される

--- a/src/main/java/net/orekyuu/libraryversionupdater/CreateLibUpdatePullRequest.java
+++ b/src/main/java/net/orekyuu/libraryversionupdater/CreateLibUpdatePullRequest.java
@@ -35,6 +35,11 @@ public class CreateLibUpdatePullRequest extends DefaultTask {
      * see: https://github.com/settings/tokens
      */
     private String githubAccessToken;
+    /**
+     * P-R's based branch name on GitHub.
+     * example: master
+     */
+    private String basedBranchName;
 
     public String getGithubPage() {
         return githubPage;
@@ -50,6 +55,14 @@ public class CreateLibUpdatePullRequest extends DefaultTask {
 
     public void setGithubAccessToken(String githubAccessToken) {
         this.githubAccessToken = githubAccessToken;
+    }
+
+    public String getBasedBranchName() {
+        return basedBranchName;
+    }
+
+    public void setBasedBranchName(String basedBranchName) {
+        this.basedBranchName = basedBranchName;
     }
 
     @TaskAction
@@ -113,7 +126,7 @@ public class CreateLibUpdatePullRequest extends DefaultTask {
             String json = "{ \"title\": \""+title +"\", " +
                     "\"body\": \""+ message.toString() +"\"," +
                     "\"head\": \""+branch+"\"," +
-                    "\"base\": \"master\"}";
+                    "\"base\": \""+ basedBranchName +"\"}";
             writer.write(json);
             writer.flush();
         }

--- a/src/main/java/net/orekyuu/libraryversionupdater/LibraryVersionUpdaterPlugin.java
+++ b/src/main/java/net/orekyuu/libraryversionupdater/LibraryVersionUpdaterPlugin.java
@@ -14,6 +14,7 @@ public class LibraryVersionUpdaterPlugin implements Plugin<Project> {
         project.getTasks().create("createLibraryUpdatePR", CreateLibUpdatePullRequest.class, (task) -> {
             task.setGithubAccessToken("default");
             task.setGithubPage("default");
+            task.setBasedBranchName("master")
             task.dependsOn("useLatestVersions");
         });
     }


### PR DESCRIPTION
closed #4 

`createLibraryUpdatePR` からbaseになるbranch名を指定できるようにした